### PR TITLE
Release build updates

### DIFF
--- a/.azure-pipelines/templates/osx/compile.yml
+++ b/.azure-pipelines/templates/osx/compile.yml
@@ -4,13 +4,18 @@ steps:
     inputs:
       packageType: sdk
       version: 6.0.201
+  
+  - task: DotNetCoreCLI@2
+    displayName: Restore solution
+    inputs:
+      command: restore
 
   - task: DotNetCoreCLI@2
     displayName: Compile common code and macOS Helpers
     inputs:
       command: build
-      projects: 'Git-Credential-Manager.sln'
-      arguments: '--configuration=Mac$(configuration) --runtime=$(osxRuntime)'
+      projects: src/osx/Installer.Mac/Installer.Mac.csproj
+      arguments: '--configuration=Mac$(configuration) --runtime=$(osxRuntime) --no-self-contained'
 
   - task: DotNetCoreCLI@2
     displayName: Run common unit tests

--- a/.azure-pipelines/templates/osx/pack.signed/step1-layout.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step1-layout.yml
@@ -1,5 +1,5 @@
 steps:
-  - script: src/osx/Installer.Mac/layout.sh --configuration='$(configuration)' --output='$(Build.StagingDirectory)/payload' --symbol-output='$(Build.StagingDirectory)/symbols --runtime=$(osxRuntime)'
+  - script: src/osx/Installer.Mac/layout.sh --configuration='$(configuration)' --output='$(Build.StagingDirectory)/payload' --symbol-output='$(Build.StagingDirectory)/symbols' --runtime='$(osxRuntime)'
     displayName: Layout installer payload
 
   - task: PublishPipelineArtifact@0

--- a/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
+++ b/src/shared/Atlassian.Bitbucket.Tests/Atlassian.Bitbucket.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/Core.Tests/Core.Tests.csproj
+++ b/src/shared/Core.Tests/Core.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/GitHub.Tests/GitHub.Tests.csproj
+++ b/src/shared/GitHub.Tests/GitHub.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/GitLab.Tests/GitLab.Tests.csproj
+++ b/src/shared/GitLab.Tests/GitLab.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
+++ b/src/shared/Microsoft.AzureRepos.Tests/Microsoft.AzureRepos.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="4.8.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
The addition of the `--runtime` parameter for macOS necessitated a few updates to our release builds. This change contains the following updates:

1. An upgrade of Microsoft.NET.Test.Sdk to the latest version.
2. Explicit specification of the macOS project we want to build.
3. A fixup to a small issue in the specification of `--runtime` in `step1-layout.yml`.

I've confirmed these changes with a [passing build](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17128354&view=results) in Azure DevOps.